### PR TITLE
Add deploy.sh run to RPC-on-RPC

### DIFF
--- a/playbooks/roles/hosts/tasks/main.yaml
+++ b/playbooks/roles/hosts/tasks/main.yaml
@@ -1,0 +1,20 @@
+---
+- name: Add root public key to authorized keys on all hosts
+  authorized_key: user=root key="{{ lookup('file', '/root/.ssh/id_rsa.pub') }}"
+
+- name: Add Nodes Hosts File Entries (Prefix)
+  lineinfile: dest=/etc/hosts line='{{ hostvars[item].management_ip }} {{ heat_stack_prefix|string }}-{{ item }}' insertafter=EOF state=present
+  with_items: groups.openstack
+
+- name: Add Nodes Hosts File Entries (Short)
+  lineinfile: dest=/etc/hosts line='{{ hostvars[item].management_ip }} {{ item }}' insertafter=EOF state=present
+  with_items: groups.openstack
+
+- name: Add Nodes Hosts File Entries (Full)
+  lineinfile: dest=/etc/hosts line='{{ hostvars[item].management_ip }} {{ heat_stack_name|string }}-{{ heat_stack_id|string }}-{{ item }}' insertafter=EOF state=present
+  with_items: groups.openstack
+
+- name: Check Connectivity
+  command: fping {{ item }}
+  changed_when: False
+  with_items: groups.openstack

--- a/playbooks/roles/packages/vars/main.yml
+++ b/playbooks/roles/packages/vars/main.yml
@@ -24,3 +24,4 @@ install:
    - libffi-dev
    - libssl-dev
    - lvm2
+   - fping

--- a/playbooks/rpc-on-rpc-playbook.yml
+++ b/playbooks/rpc-on-rpc-playbook.yml
@@ -1,21 +1,20 @@
 ---
 # This playbook installs Rackspace Private Cloud v13.1
-
-- name: Do Nothing
+- name: Install Packages
   hosts: all
-  tags:
-    - prepare
-  tasks:
-    - name: Ping Nodes
-      ping:
-
-- name: Prepare Environment
-  hosts: all:!deployment
   tags:
     - prepare
     - packages
   roles:
     - packages
+
+- name: Setup Host Files
+  hosts: all
+  tags:
+    - prepare
+    - hosts
+  roles:
+    - hosts
 
 - name: Setup Cinder Volume Groups
   hosts: block
@@ -34,7 +33,7 @@
     - mounts
 
 - name: Setup Networking
-  hosts: all:!deployment
+  hosts: openstack
   tags:
     - prepare
     - networking
@@ -50,7 +49,7 @@
     - configure-rpc
 
 - name: Reboot Cluster
-  hosts: all:!deployment
+  hosts: openstack
   tags:
     - reboot
   roles:

--- a/templates/rpc-on-rpc-full.yml
+++ b/templates/rpc-on-rpc-full.yml
@@ -874,7 +874,7 @@ resources:
                   heat_stack_id=%heat_stack_id%
                   heat_stack_name=%heat_stack_name%
                   heat_stack_password=%heat_stack_password%
-                  heat_stack_prefix=%heat_stack_name%-%heat_stack_id%
+                  heat_stack_prefix=%heat_stack_name%
                   rpc_branch=%rpc_branch%
                   deploy_retries=%deploy_retries%
 
@@ -919,6 +919,14 @@ resources:
                   object01 management_ip=%object01_management_ip% storage_ip=%object01_storage_ip%
                   object02 management_ip=%object02_management_ip% storage_ip=%object02_storage_ip%
                   object03 management_ip=%object03_management_ip% storage_ip=%object03_storage_ip%
+
+                  [openstack:children]
+                  haproxy
+                  infra
+                  logger
+                  compute
+                  block
+                  object
                 params:
                   "%heat_stack_id%":            { get_param: "OS::stack_id" }
                   "%heat_stack_name%":          { get_param: "OS::stack_name" }
@@ -1619,6 +1627,9 @@ resources:
         set -e
         set -x
 
+        # Set Ansible FORKS
+        export FORKS=10
+
         logdir=/var/log/heat-deployments
         prefix=${logdir}/config-rpc-software
 
@@ -1770,8 +1781,11 @@ resources:
         set -e
         set -x
 
-        logdir=/var/log/heat-deployments
-        prefix=${logdir}/config-rpc-software
+        # Set RPC deploy.sh bash environment variables
+        export DEPLOY_TEMPEST="yes"
+        export DEPLOY_HAPROXY="yes"
+        export DEPLOY_MAAS="no"
+        export FORKS=15
 
         function exit_failure {
           echo "FAILURE: '$@'"
@@ -1783,7 +1797,19 @@ resources:
           exit 0
         }
 
+        logdir=/var/log/heat-deployments
+        prefix=${logdir}/rpc-software-deploy
+
+        # Set log file
+        mkdir -p $logdir
+        exec &> >(tee -a ${prefix}.log)
+        [ -e ${prefix}.ran ] && exit 0
+        chmod -R 0600 ${logdir}
+
         echo "Deploy RPC Software"
+        pushd /opt/rpc-openstack/
+        ./scripts/deploy.sh || exit_failure "RPC deploy.sh Failure"
+        popd
 
         exit_success
 


### PR DESCRIPTION
- added deploy.sh to software config to run rpc script deploy.sh
- removed full hostname from inventory file to match < 64 length hostnames
- added host file config for host names
- added openstack child group to make plays easier to target hosts

Fixes #10 